### PR TITLE
Update Create_Test_Environment.md

### DIFF
--- a/host/Create_Test_Environment.md
+++ b/host/Create_Test_Environment.md
@@ -52,7 +52,7 @@ We will use docker, on its own, to create the OpenVPN, DNS, and Bugzilla servers
 ```bash
 # Create the Test Environment containers
 cd ~/Lab2/host
-docker-compose -d -f compose1.yml up
+docker-compose -f compose1.yml up -d
 ```
 
 ```bash


### PR DESCRIPTION
-d is an option for up

You can check "docker-compose help" and will see no option for up but when you run "docker-compose help up" you will see the option, therefore -d need to be after up 

Sincerely 
Andreas